### PR TITLE
fix: treesitter/lsp colors

### DIFF
--- a/lua/solarized/colors.lua
+++ b/lua/solarized/colors.lua
@@ -1,76 +1,75 @@
 local bases = {
-	base03 =        '#002b36',
-	base02 =        '#073642',
-	base01 =        '#586e75',
-	base00 =        '#657b83',
-	base0 =         '#839496',
-	base1 =         '#93a1a1',
-	base2 =         '#eee8d5',
-	base3 =         '#fdf6e3',
+    base03 = '#002b36',
+    base02 = '#073642',
+    base01 = '#586e75',
+    base00 = '#657b83',
+    base0  = '#839496',
+    base1  = '#93a1a1',
+    base2  = '#eee8d5',
+    base3  = '#fdf6e3',
 }
 
 local solarized = {
+    white        = '#eee8d5',
+    gray         = '#073642',
+    black        = '#002b36',
+    red          = '#dc322f',
+    green        = '#859900',
+    yellow       = '#b58900',
+    paleblue     = '#586e75',
+    cyan         = '#2aa198',
+    blue         = '#268bd2',
+    purple       = '#6c71c4',
+    orange       = '#cb4b16',
+    magenta      = '#d33682',
+    violet       = '#6c71c4',
 
-	white =         '#eee8d5',
-	gray =          '#073642',
-	black =         '#002b36',
-	red =           '#dc322f',
-	green =         '#859900',
-	yellow =        '#b58900',
-	paleblue =      '#586e75',
-	cyan =          '#2aa198',
-	blue =          '#268bd2',
-	purple =        '#6c71c4',
-	orange =        '#cb4b16',
-	magenta =       '#d33682',
-	violet =        '#6c71c4',
+    bg_light     = bases['base3'],
+    bg_light_alt = bases['base2'],
+    bg_dark      = bases['base03'],
+    bg_dark_alt  = bases['base02'],
+    fg_light     = bases['base0'],
+    text_light   = bases['base1'],
+    fg_dark      = bases['base00'],
+    text_dark    = bases['base01'],
+    comments     = '#657b83',
+    selection    = '#d3cfc1',
+    contrast     = '#002b36',
+    active       = '#d8ccc4',
+    border       = '#002b36',
+    line_numbers = '#839496',
+    highlight    = '#d8ccc4',
+    disabled     = '#073642',
+    cursor       = '#268bd2',
+    accent       = '#073642',
 
-	bg_light =       bases['base3'],
-	bg_light_alt =   bases['base2'],
-	bg_dark =        bases['base03'],
-	bg_dark_alt =    bases['base02'],
-	fg_light =       bases['base0'],
-	text_light =     bases['base1'],
-	fg_dark =        bases['base00'],
-	text_dark =      bases['base01'],
-	comments =      '#657b83',
-	selection =     '#d3cfc1',
-	contrast =      '#002b36',
-	active =        '#d8ccc4',
-	border =        '#002b36',
-	line_numbers =  '#839496',
-	highlight =     '#d8ccc4',
-	disabled =      '#073642',
-	cursor =        '#268bd2',
-	accent =        '#073642',
+    error        = '#dc322f',
+    link         = '#2aa198',
 
-	error =         '#dc322f',
-	link =          '#2aa198',
-
-	none =          'NONE'
+    none         = 'NONE'
 }
 
 -- If dark mode, swap fg and bg
 if vim.o.background == 'dark' then
-	solarized.bg = solarized.bg_dark
-	solarized.bg_alt = solarized.bg_dark_alt
-	solarized.fg = solarized.fg_dark
-	solarized.text = solarized.text_dark
+    solarized.bg     = solarized.bg_dark
+    solarized.bg_alt = solarized.bg_dark_alt
+    solarized.fg     = solarized.fg_dark
+    solarized.text   = solarized.text_dark
 else
-	solarized.bg = solarized.bg_light
-	solarized.bg_alt = solarized.bg_light_alt
-	solarized.fg = solarized.fg_light
-	solarized.text = solarized.text_light
+    solarized.bg     = solarized.bg_light
+    solarized.bg_alt = solarized.bg_light_alt
+    solarized.fg     = solarized.fg_light
+    solarized.text   = solarized.text_light
 end
 -- Optional colors
 
 -- Enable contrast sidebars, floating windows and popup menus
 if vim.g.solarized_contrast == false then
     solarized.sidebar = solarized.bg
-    solarized.float = solarized.bg
+    solarized.float   = solarized.bg
 else
     solarized.sidebar = solarized.bg_alt
-    solarized.float = solarized.bg_alt
+    solarized.float   = solarized.bg_alt
 end
 
 return solarized

--- a/lua/solarized/init.lua
+++ b/lua/solarized/init.lua
@@ -13,7 +13,7 @@
 local util = require('solarized.util')
 
 -- Load the theme
-local set = function ()
+local set = function()
     util.load()
 end
 

--- a/lua/solarized/theme.lua
+++ b/lua/solarized/theme.lua
@@ -1,460 +1,471 @@
-local solarized = require("solarized.colors")
+local solarized = require('solarized.colors')
+
+local ts = require('solarized.treesitter')
 
 local theme = {}
 
-theme.loadSyntax = function ()
+theme.loadSyntax = function()
     -- Syntax highlight groups
 
-	local syntax = {
-		Type =						{ fg = solarized.yellow }, -- int, long, char, etc.
-		StorageClass =				{ fg = solarized.cyan }, -- static, register, volatile, etc.
-		Structure =					{ fg = solarized.yellow }, -- struct, union, enum, etc.
-		Constant =					{ fg = solarized.purple }, -- any constant
-		String =					{ fg = solarized.green, bg = solarized.none, style= 'italic' }, -- Any string
-		Character =					{ fg = solarized.orange }, -- any character constant: 'c', '\n'
-		Number =					{ fg = solarized.orange }, -- a number constant: 5
-		Boolean =					{ fg = solarized.orange }, -- a boolean constant: TRUE, false
-		Float =						{ fg = solarized.orange }, -- a floating point constant: 2.3e10
-		Statement =					{ fg = solarized.gray }, -- any statement
-		Label =						{ fg = solarized.yellow }, -- case, default, etc.
-		Operator =					{ fg = solarized.cyan }, -- sizeof", "+", "*", etc.
-		Exception =					{ fg = solarized.cyan }, -- try, catch, throw
-		PreProc =					{ fg = solarized.yellow }, -- generic Preprocessor
-		Include =					{ fg = solarized.blue }, -- preprocessor #include
-		Define =					{ fg = solarized.gray }, -- preprocessor #define
-		Macro =						{ fg = solarized.cyan }, -- same as Define
-		Typedef =					{ fg = solarized.red }, -- A typedef
-		PreCondit =					{ fg = solarized.cyan }, -- preprocessor #if, #else, #endif, etc.
-		Special =					{ fg = solarized.red }, -- any special symbol
-		SpecialChar =				{ fg = solarized.gray }, -- special character in a constant
-		Tag =						{ fg = solarized.red }, -- you can use CTRL-] on this
-		Delimiter =					{ fg = solarized.cyan }, -- character that needs attention like , or .
-		SpecialComment =			{ fg = solarized.gray }, -- special things inside a comment
-		Debug =						{ fg = solarized.red }, -- debugging statements
-		Underlined =				{ fg = solarized.link, bg = solarized.none, style = 'underline' }, -- text that stands out, HTML links
-		Ignore =					{ fg = solarized.disabled }, -- left blank, hidden
-		Error =						{ fg = solarized.error, bg = solarized.none, style = 'bold,underline' }, -- any erroneous construct
-		Todo =						{ fg = solarized.purple, bg = solarized.none, style = 'bold,italic' }, -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    local syntax = {
+        Statement           = { fg = solarized.gray },      -- any statement
+        Ignore              = { fg = solarized.disabled },  -- left blank, hidden
 
-        htmlLink = { fg = solarized.link, style = "underline" },
-        htmlH1 = { fg = solarized.cyan, style = "bold" },
-        htmlH2 = { fg = solarized.red, style = "bold" },
-        htmlH3 = { fg = solarized.green, style = "bold" },
-        htmlH4 = { fg = solarized.purple, style = "bold" },
-        htmlH5 = { fg = solarized.yellow, style = "bold" },
-        markdownH1 = { fg = solarized.cyan, style = "bold" },
-        markdownH2 = { fg = solarized.red, style = "bold" },
-        markdownH3 = { fg = solarized.green, style = "bold" },
+        Structure           = ts['@namespace'],             -- struct, union, enum, etc.
+        Typedef             = ts['@type.definition'],       -- A typedef
+
+        Type                = ts['@type'],                  -- int, long, char, etc.
+        StorageClass        = ts['@storageclass'],          -- static, register, volatile, etc.
+        Constant            = ts['@constant'],              -- any constant
+        String              = ts['@string'],                -- Any string
+        Character           = ts['@character'],             -- any character constant: 'c', '\n'
+        Number              = ts['@number'],                -- a number constant: 5
+        Boolean             = ts['@boolean'],               -- a boolean constant: TRUE, false
+        Float               = ts['@float'],                 -- a floating point constant: 2.3e10
+        Label               = ts['@label'],                 -- case, default, etc.
+        Operator            = ts['@operator'],              -- sizeof", "+", "*", etc.
+        Exception           = ts['@exception'],             -- try, catch, throw
+        PreProc             = ts['@preproc'],               -- generic Preprocessor
+        Include             = ts['@include'],               -- preprocessor #include
+        Define              = ts['@define'],                -- preprocessor #define
+        Macro               = ts['@function.macro'],
+        PreCondit           = ts['@conditional'],           -- preprocessor #if, #else, #endif, etc.
+        Special             = ts['@string.special'],        -- any special symbol
+        SpecialChar         = ts['@character.special'],     -- special character in a constant
+        Tag                 = ts['@tag'],                   -- you can use CTRL-] on this
+        Delimiter           = ts['@punctuation.delimiter'], -- character that needs attention like , or .
+        SpecialComment      = ts['@comment.documentation'], -- special things inside a comment
+        Debug               = ts['@debug'],                 -- debugging statements
+        Underlined          = ts['@text.underline'],        -- text that stands out, HTML links
+        Error               = ts['@error'],                 -- any erroneous construct
+        Todo                = ts['@text.todo'],             -- anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+
+        htmlLink            = { fg = solarized.link, style = 'underline' },
+        htmlH1              = { fg = solarized.cyan, style = 'bold' },
+        htmlH2              = { fg = solarized.red, style = 'bold' },
+        htmlH3              = { fg = solarized.green, style = 'bold' },
+        htmlH4              = { fg = solarized.purple, style = 'bold' },
+        htmlH5              = { fg = solarized.yellow, style = 'bold' },
+        markdownH1          = { fg = solarized.cyan, style = 'bold' },
+        markdownH2          = { fg = solarized.red, style = 'bold' },
+        markdownH3          = { fg = solarized.green, style = 'bold' },
         markdownH1Delimiter = { fg = solarized.cyan },
         markdownH2Delimiter = { fg = solarized.red },
         markdownH3Delimiter = { fg = solarized.green },
-	}
-
-	-- Options:
-
-	-- Italic comments
-	if vim.g.solarized_italic_comments == true then
-		syntax.Comment =		{fg = solarized.comments, bg = solarized.none, style = 'italic'} -- italic comments
-	else
-		syntax.Comment =		{fg = solarized.comments} -- normal comments
-	end
-
-	-- Italic Keywords
-	if vim.g.solarized_italic_keywords == true then
-		syntax.Conditional =		{fg = solarized.yellow, bg = solarized.none, style = 'italic'} -- italic if, then, else, endif, switch, etc.
-		syntax.Keyword =			{fg = solarized.yellow, bg = solarized.none, style = 'italic'} -- italic for, do, while, etc.
-		syntax.Repeat =				{fg = solarized.yellow, bg = solarized.none, style = 'italic'} -- italic any other keyword
-	else
-		syntax.Conditional =		{fg = solarized.yellow} -- normal if, then, else, endif, switch, etc.
-		syntax.Keyword =			{fg = solarized.yellow} -- normal for, do, while, etc.
-		syntax.Repeat =				{fg = solarized.yellow} -- normal any other keyword
-	end
-
-	-- Italic Function names
-	if vim.g.solarized_italic_functions == true then
-		syntax.Function =		{fg = solarized.blue, bg = solarized.none, style = 'italic'} -- italic funtion names
-	else
-		syntax.Function =		{fg = solarized.blue} -- normal function names
-	end
-
-	if vim.g.solarized_italic_variables == true then
-		syntax.Identifier =				{fg = solarized.gray, bg = solarized.none, style = 'italic'}; -- any variable name
-    else
-		syntax.Identifier =				{fg = solarized.gray}; -- any variable name
-    end
-
-    return syntax
-
-end
-
-
-theme.loadEditor = function ()
-    -- Editor highlight groups
-
-	local editor = {
-		NormalFloat =			{ fg = solarized.fg, bg = solarized.float }, -- normal text and background color
-		ColorColumn =			{ fg = solarized.none, bg = solarized.active }, --  used for the columns set with 'colorcolumn'
-		Conceal =				{ fg = solarized.disabled }, -- placeholder characters substituted for concealed text (see 'conceallevel')
-		Cursor =				{ fg = solarized.cursor, bg = solarized.none, style = 'reverse' }, -- the character under the cursor
-		CursorIM =				{ fg = solarized.cursor, bg = solarized.none, style = 'reverse' }, -- like Cursor, but used when in IME mode
-		Directory =				{ fg = solarized.blue, bg = solarized.none }, -- directory names (and other special names in listings)
-		DiffAdd =				{ fg = solarized.green, bg = solarized.none, style = 'reverse' }, -- diff mode: Added line
-		DiffChange =			{ fg = solarized.orange, bg = solarized.none, style = 'reverse' }, --  diff mode: Changed line
-		DiffDelete =			{ fg = solarized.red, bg = solarized.none, style = 'reverse' }, -- diff mode: Deleted line
-		DiffText =				{ fg = solarized.purple, bg = solarized.none, style = 'reverse' }, -- diff mode: Changed text within a changed line
-		EndOfBuffer =			{ fg = solarized.disabled },
-		ErrorMsg =				{ fg = solarized.none },
-		Folded =				{ fg = solarized.disabled, bg = solarized.none, style = 'italic' },
-		FoldColumn =			{ fg = solarized.blue },
-		IncSearch =				{ fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
-		LineNr =				{ fg = solarized.line_numbers, bg = solarized.bg_alt },
-		CursorLineNr =			{ fg = solarized.accent },
-		MatchParen =			{ fg = solarized.purple, bg = solarized.none, style = 'bold' },
-		ModeMsg =				{ fg = solarized.accent },
-		MoreMsg =				{ fg = solarized.accent },
-		NonText =				{ fg = solarized.disabled },
-		Pmenu =					{ fg = solarized.fg, bg = solarized.none },
-		PmenuSel =				{ fg = solarized.accent, bg = solarized.active },
-		PmenuSbar =				{ fg = solarized.text, bg = solarized.contrast },
-		PmenuThumb =			{ fg = solarized.fg, bg = solarized.accent },
-		Question =				{ fg = solarized.green },
-		QuickFixLine =			{ fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
-		qfLineNr =				{ fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
-		Search =				{ fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
-		SpecialKey =			{ fg = solarized.yellow },
-		SpellBad =				{ fg = solarized.red, bg = solarized.none, style = 'italic,undercurl' },
-		SpellCap =				{ fg = solarized.blue, bg = solarized.none, style = 'italic,undercurl' },
-		SpellLocal =			{ fg = solarized.cyan, bg = solarized.none, style = 'italic,undercurl' },
-		SpellRare =				{ fg = solarized.yellow, bg = solarized.none, style = 'italic,undercurl' },
-		StatusLine =			{ fg = solarized.fg, bg = solarized.contrast },
-		StatusLineNC =  		{ fg = solarized.text, bg = solarized.disabled },
-		StatusLineTerm =		{ fg = solarized.fg, bg = solarized.contrast },
-		StatusLineTermNC =		{ fg = solarized.text, bg = solarized.disabled },
-		TabLineFill =			{ fg = solarized.fg },
-		TablineSel =			{ fg = solarized.bg, bg = solarized.accent },
-		Tabline =				{ fg = solarized.fg },
-		Title =					{ fg = solarized.green, bg = solarized.none, style = 'bold' },
-		Visual =				{ fg = solarized.none, bg = solarized.selection },
-		VisualNOS =				{ fg = solarized.none, bg = solarized.selection },
-		WarningMsg =			{ fg = solarized.purple },
-		WildMenu =				{ fg = solarized.orange, bg = solarized.none, style = 'bold' },
-		CursorColumn =			{ fg = solarized.none, bg = solarized.active },
-		CursorLine =			{ fg = solarized.none, bg = solarized.bg_alt },
-		ToolbarLine =			{ fg = solarized.fg, bg = solarized.bg_alt },
-		ToolbarButton =			{ fg = solarized.fg, bg = solarized.none, style = 'bold' },
-		NormalMode =			{ fg = solarized.accent, bg = solarized.none, style = 'reverse' },
-		InsertMode =			{ fg = solarized.green, bg = solarized.none, style = 'reverse' },
-		ReplacelMode =			{ fg = solarized.red, bg = solarized.none, style = 'reverse' },
-		VisualMode =			{ fg = solarized.yellow, bg = solarized.none, style = 'reverse' },
-		CommandMode =			{ fg = solarized.gray, bg = solarized.none, style = 'reverse' },
-		Warnings =				{ fg = solarized.purple },
-
-        healthError =           { fg = solarized.error },
-        healthSuccess =         { fg = solarized.green },
-        healthWarning =         { fg = solarized.purple },
-
-        -- Dashboard
-        DashboardShortCut =                     { fg = solarized.gray },
-        DashboardHeader =                       { fg = solarized.gray },
-        DashboardCenter =                       { fg = solarized.gray },
-        DashboardFooter =                       { fg = solarized.green, style = "italic" },
-
-	}
-
-    -- Options:
-
-    --Set transparent background
-    if vim.g.solarized_disable_background == true then
-		editor.Normal =				{ fg = solarized.fg, bg = solarized.none } -- normal text and background color
-		editor.SignColumn =			{ fg = solarized.fg, bg = solarized.none }
-    else
-		editor.Normal =				{ fg = solarized.fg, bg = solarized.bg } -- normal text and background color
-		editor.SignColumn =			{ fg = solarized.fg, bg = solarized.bg }
-    end
-
-    -- Remove window split borders
-    if vim.g.solarized_borders == true then
-		editor.VertSplit =				{ fg = solarized.border }
-    else
-		editor.VertSplit =				{ fg = solarized.bg }
-    end
-
-    return editor
-end
-
-theme.loadTerminal = function ()
-
-	vim.g.terminal_color_0 = solarized.black
-	vim.g.terminal_color_1 = solarized.red
-	vim.g.terminal_color_2 = solarized.green
-	vim.g.terminal_color_3 = solarized.purple
-	vim.g.terminal_color_4 = solarized.blue
-	vim.g.terminal_color_5 = solarized.yellow
-	vim.g.terminal_color_6 = solarized.cyan
-	vim.g.terminal_color_7 = solarized.white
-	vim.g.terminal_color_8 = solarized.gray
-	vim.g.terminal_color_9 = solarized.red
-	vim.g.terminal_color_10 = solarized.green
-	vim.g.terminal_color_11 = solarized.purple
-	vim.g.terminal_color_12 = solarized.blue
-	vim.g.terminal_color_13 = solarized.yellow
-	vim.g.terminal_color_14 = solarized.cyan
-	vim.g.terminal_color_15 = solarized.white
-
-end
-
-theme.loadTreeSitter = function ()
-    -- TreeSitter highlight groups
-
-    local treesitter = {
-        TSAnnotation =              { fg = solarized.red, style = 'bold' },    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
-        TSAttribute =               { fg = solarized.purple},    -- (unstable) TODO: docs
-        TSBoolean=                  { fg = solarized.orange},    -- For booleans.
-        TSCharacter=                { fg = solarized.orange},    -- For characters.
-        TSConstructor =             { fg = solarized.yellow}, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
-        TSConstant =                { fg = solarized.purple },    -- For constants
-        TSConstBuiltin =            { fg = solarized.blue },    -- For constant that are built in the language: `nil` in Lua.
-        TSConstMacro =              { fg = solarized.blue },    -- For constants that are defined by macros: `NULL` in C.
-        TSError =                   { fg = solarized.error, style = 'bold' },    -- For syntax/parser errors.
-        TSException =               { fg = solarized.purple, style = 'bold' },    -- For exception related keywords.
-        TSField =                   { fg = solarized.gray}, -- For fields.
-        TSFloat =                   { fg = solarized.red},    -- For floats.
-        TSFuncMacro =               { fg = solarized.blue },    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-        TSInclude =                 { fg = solarized.cyan, style = 'bold' },    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-        TSLabel =                   { fg = solarized.red }, -- For labels: `label:` in C and `:label:` in Lua.
-        TSNamespace =               { fg = solarized.purple },    -- For identifiers referring to modules and namespaces.
-        --TSNone =                    { },    -- TODO: docs
-        TSNumber =                  { fg = solarized.orange},    -- For all numbers
-        TSOperator =                { fg = solarized.black}, -- For any operator: `+`, but also `->` and `*` in C.
-        TSParameter =               { fg = solarized.green }, -- For parameters of a function.
-        TSParameterReference=       { fg = solarized.green },    -- For references to parameters of a function.
-        TSProperty =                { fg = solarized.green }, -- Same as `TSField`.
-        TSPunctDelimiter =          { fg = solarized.black }, -- For delimiters ie: `.`
-        TSPunctBracket =            { fg = solarized.black }, -- For brackets and parens.
-        TSPunctSpecial =            { fg = solarized.black }, -- For special punctutation that does not fall in the catagories before.
-        TSString =                  { fg = solarized.link },    -- For strings.
-        TSStringRegex =             { fg = solarized.blue }, -- For regexes.
-        TSStringEscape =            { fg = solarized.disabled }, -- For escape characters within a string.
-        TSSymbol =                  { fg = solarized.purple},    -- For identifiers referring to symbols or atoms.
-        TSType =                    { fg = solarized.yellow, style = 'bold' },    -- For types.
-        TSTypeBuiltin =             { fg = solarized.yellow },    -- For builtin types.
-        TSTag =                     { fg = solarized.red, style = 'bold' },    -- Tags like html tag names.
-        TSTagDelimiter =            { fg = solarized.purple },    -- Tag delimiter like `<` `>` `/`
-        TSText =                    { fg = solarized.text },    -- For strings considered text in a markup language.
-        TSTextReference =           { fg = solarized.purple }, -- FIXME
-        TSEmphasis =                { fg = solarized.paleblue, style = 'bold' },    -- For text to be represented with emphasis.
-        TSUnderline =               { fg = solarized.fg, bg = solarized.none, style = 'underline' },    -- For text to be represented with an underline.
-        TSStrike =                  { },    -- For strikethrough text.
-        TSTitle =                   { fg = solarized.paleblue, bg = solarized.none, style = 'bold' },    -- Text that is part of a title.
-        TSLiteral =                 { fg = solarized.fg},    -- Literal text.
-        TSURI =                     { fg = solarized.link },    -- Any URI like a link or email.
     }
 
     -- Options:
 
     -- Italic comments
     if vim.g.solarized_italic_comments == true then
-        treesitter.TSComment=                  { fg = solarized.comments , bg = solarized.none, style = 'bold,italic' }    -- For comment blocks.
+        syntax.Comment = { fg = solarized.comments, bg = solarized.none, style = 'italic' } -- italic comments
     else
-        treesitter.TSComment=                  { fg = solarized.comments }    -- For comment blocks.
+        syntax.Comment = ts['@comment'];                                                    -- normal comments
     end
 
+    -- Italic Keywords
     if vim.g.solarized_italic_keywords == true then
-        treesitter.TSConditional =             { fg = solarized.greeen, style = 'italic' }    -- For keywords related to conditionnals.
-        treesitter.TSKeyword =                 { fg = solarized.green, style = 'italic' } -- For keywords that don't fall in previous categories.
-        treesitter.TSRepeat =                  { fg = solarized.green, style = 'bold,italic' }    -- For keywords related to loops.
-        treesitter.TSKeywordFunction =         { fg = solarized.green, style = 'bold,italic' } -- For keywords used to define a fuction.
+        syntax.Conditional = { fg = solarized.yellow, bg = solarized.none, style = 'italic' } -- italic if, then, else, endif, switch, etc.
+        syntax.Keyword     = { fg = solarized.yellow, bg = solarized.none, style = 'italic' } -- italic for, do, while, etc.
+        syntax.Repeat      = { fg = solarized.yellow, bg = solarized.none, style = 'italic' } -- italic any other keyword
     else
-        treesitter.TSConditional =             { fg = solarized.green}    -- For keywords related to conditionnals.
-        treesitter.TSKeyword =                 { fg = solarized.green} -- For keywords that don't fall in previous categories.
-        treesitter.TSRepeat =                  { fg = solarized.green, style = 'bold' }    -- For keywords related to loops.
-        treesitter.TSKeywordFunction =         { fg = solarized.green, style = 'bold' } -- For keywords used to define a fuction.
+        syntax.Conditional = ts['@conditional'];                                              -- normal if, then, else, endif, switch, etc.
+        syntax.Keyword     = ts['@keyword'];                                                  -- normal for, do, while, etc.
+        syntax.Repeat      = ts['@repeat'];                                                   -- normal any other keyword
     end
 
+    -- Italic Function names
     if vim.g.solarized_italic_functions == true then
-        treesitter.TSFunction =                { fg = solarized.yellow, style = 'bold,italic' }    -- For fuction (calls and definitions).
-        treesitter.TSMethod =                  { fg = solarized.yellow, style = 'bold,italic' }    -- For method calls and definitions.
-        treesitter.TSFuncBuiltin =             { fg = solarized.purple, style = 'bold,italic' }    -- For builtin functions: `table.insert` in Lua.
+        syntax.Function = { fg = solarized.blue, bg = solarized.none, style = 'italic' } -- italic funtion names
     else
-        treesitter.TSFunction =                { fg = solarized.yellow, style = 'bold' }    -- For fuction (calls and definitions).
-        treesitter.TSMethod =                  { fg = solarized.yellow, style = 'bold' }    -- For method calls and definitions.
-        treesitter.TSFuncBuiltin =             { fg = solarized.purple, style = 'bold' }    -- For builtin functions: `table.insert` in Lua.
+        syntax.Function = ts['function']                                                 -- normal function names
     end
 
     if vim.g.solarized_italic_variables == true then
-        treesitter.TSVariable =                { fg = solarized.gray, style = 'italic' } -- Any variable name that does not have another highlight.
-        treesitter.TSVariableBuiltin =         { fg = solarized.gray, style = 'italic' } -- Variable names that are defined by the languages, like `this` or `self`.
+        syntax.Identifier = { fg = solarized.gray, bg = solarized.none, style = 'italic' }; -- any variable name
     else
-        treesitter.TSVariable =                { fg = solarized.cursor} -- Any variable name that does not have another highlight.
-        treesitter.TSVariableBuiltin =         { fg = solarized.cursor} -- Variable names that are defined by the languages, like `this` or `self`.
+        syntax.Identifier = ts['@variable'];                                                -- any variable name
     end
 
-    return treesitter
-
+    return syntax
 end
 
-theme.loadLSP = function ()
+
+theme.loadEditor = function()
+    -- Editor highlight groups
+
+    local editor = {
+        NormalFloat       = { fg = solarized.fg, bg = solarized.float },                       -- normal text and background color
+        ColorColumn       = { fg = solarized.none, bg = solarized.active },                    --  used for the columns set with 'colorcolumn'
+        Conceal           = { fg = solarized.disabled },                                       -- placeholder characters substituted for concealed text (see 'conceallevel')
+        Cursor            = { fg = solarized.cursor, bg = solarized.none, style = 'reverse' }, -- the character under the cursor
+        CursorIM          = { fg = solarized.cursor, bg = solarized.none, style = 'reverse' }, -- like Cursor, but used when in IME mode
+        Directory         = { fg = solarized.blue, bg = solarized.none },                      -- directory names (and other special names in listings)
+        DiffAdd           = { fg = solarized.green, bg = solarized.none, style = 'reverse' },  -- diff mode: Added line
+        DiffChange        = { fg = solarized.orange, bg = solarized.none, style = 'reverse' }, --  diff mode: Changed line
+        DiffDelete        = { fg = solarized.red, bg = solarized.none, style = 'reverse' },    -- diff mode: Deleted line
+        DiffText          = { fg = solarized.purple, bg = solarized.none, style = 'reverse' }, -- diff mode: Changed text within a changed line
+        EndOfBuffer       = { fg = solarized.disabled },
+        ErrorMsg          = { fg = solarized.none },
+        Folded            = { fg = solarized.disabled, bg = solarized.none, style = 'italic' },
+        FoldColumn        = { fg = solarized.blue },
+        IncSearch         = { fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
+        LineNr            = { fg = solarized.line_numbers, bg = solarized.bg_alt },
+        CursorLineNr      = { fg = solarized.accent },
+        MatchParen        = { fg = solarized.purple, bg = solarized.bg_alt, style = 'bold' },
+        ModeMsg           = { fg = solarized.accent },
+        MoreMsg           = { fg = solarized.accent },
+        NonText           = { fg = solarized.disabled },
+        Pmenu             = { fg = solarized.fg, bg = solarized.none },
+        PmenuSel          = { fg = solarized.accent, bg = solarized.active },
+        PmenuSbar         = { fg = solarized.text, bg = solarized.contrast },
+        PmenuThumb        = { fg = solarized.fg, bg = solarized.accent },
+        Question          = { fg = solarized.green },
+        QuickFixLine      = { fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
+        qfLineNr          = { fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
+        Search            = { fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
+        SpecialKey        = { fg = solarized.yellow },
+        SpellBad          = { fg = solarized.red, bg = solarized.none, style = 'italic,undercurl' },
+        SpellCap          = { fg = solarized.blue, bg = solarized.none, style = 'italic,undercurl' },
+        SpellLocal        = { fg = solarized.cyan, bg = solarized.none, style = 'italic,undercurl' },
+        SpellRare         = { fg = solarized.yellow, bg = solarized.none, style = 'italic,undercurl' },
+        StatusLine        = { fg = solarized.fg, bg = solarized.contrast },
+        StatusLineNC      = { fg = solarized.text, bg = solarized.disabled },
+        StatusLineTerm    = { fg = solarized.fg, bg = solarized.contrast },
+        StatusLineTermNC  = { fg = solarized.text, bg = solarized.disabled },
+        TabLineFill       = { fg = solarized.fg },
+        TablineSel        = { fg = solarized.bg, bg = solarized.accent },
+        Tabline           = { fg = solarized.fg },
+        Title             = { fg = solarized.green, bg = solarized.none, style = 'bold' },
+        Visual            = { fg = solarized.none, bg = solarized.selection },
+        VisualNOS         = { fg = solarized.none, bg = solarized.selection },
+        WarningMsg        = { fg = solarized.purple },
+        WildMenu          = { fg = solarized.orange, bg = solarized.none, style = 'bold' },
+        CursorColumn      = { fg = solarized.none, bg = solarized.active },
+        CursorLine        = { fg = solarized.none, bg = solarized.bg_alt },
+        ToolbarLine       = { fg = solarized.fg, bg = solarized.bg_alt },
+        ToolbarButton     = { fg = solarized.fg, bg = solarized.none, style = 'bold' },
+        NormalMode        = { fg = solarized.accent, bg = solarized.none, style = 'reverse' },
+        InsertMode        = { fg = solarized.green, bg = solarized.none, style = 'reverse' },
+        ReplacelMode      = { fg = solarized.red, bg = solarized.none, style = 'reverse' },
+        VisualMode        = { fg = solarized.yellow, bg = solarized.none, style = 'reverse' },
+        CommandMode       = { fg = solarized.gray, bg = solarized.none, style = 'reverse' },
+        Warnings          = { fg = solarized.purple },
+
+        healthError       = { fg = solarized.error },
+        healthSuccess     = { fg = solarized.green },
+        healthWarning     = { fg = solarized.purple },
+
+        -- Dashboard
+        DashboardShortCut = { fg = solarized.gray },
+        DashboardHeader   = { fg = solarized.gray },
+        DashboardCenter   = { fg = solarized.gray },
+        DashboardFooter   = { fg = solarized.green, style = 'italic' },
+
+    }
+
+    -- Options:
+
+    --Set transparent background
+    if vim.g.solarized_disable_background == true then
+        editor.Normal     = { fg = solarized.fg, bg = solarized.none } -- normal text and background color
+        editor.SignColumn = { fg = solarized.fg, bg = solarized.none }
+    else
+        editor.Normal     = { fg = solarized.fg, bg = solarized.bg } -- normal text and background color
+        editor.SignColumn = { fg = solarized.fg, bg = solarized.bg }
+    end
+
+    -- Remove window split borders
+    if vim.g.solarized_borders == true then
+        editor.VertSplit = { fg = solarized.border }
+    else
+        editor.VertSplit = { fg = solarized.bg }
+    end
+
+    return editor
+end
+
+theme.loadTerminal = function()
+    vim.g.terminal_color_0 = solarized.black
+    vim.g.terminal_color_1 = solarized.red
+    vim.g.terminal_color_2 = solarized.green
+    vim.g.terminal_color_3 = solarized.purple
+    vim.g.terminal_color_4 = solarized.blue
+    vim.g.terminal_color_5 = solarized.yellow
+    vim.g.terminal_color_6 = solarized.cyan
+    vim.g.terminal_color_7 = solarized.white
+    vim.g.terminal_color_8 = solarized.gray
+    vim.g.terminal_color_9 = solarized.red
+    vim.g.terminal_color_10 = solarized.green
+    vim.g.terminal_color_11 = solarized.purple
+    vim.g.terminal_color_12 = solarized.blue
+    vim.g.terminal_color_13 = solarized.yellow
+    vim.g.terminal_color_14 = solarized.cyan
+    vim.g.terminal_color_15 = solarized.white
+end
+
+theme.loadTreeSitter = function()
+    -- TreeSitter highlight groups
+
+    local treesitter = {
+        TSAttribute              = ts['@attribute'],
+        TSBoolean                = ts['@boolean'],
+        TSCharacter              = ts['@character'],
+        TSConstructor            = ts['@constructor'],
+        TSConstant               = ts['@constant'],
+        TSConstBuiltin           = ts['@constant.builtin'],
+        TSConstMacro             = ts['@constant.macro'],
+        TSError                  = ts['@error'],
+        TSException              = ts['@exception'],
+        TSField                  = ts['@field'],
+        TSFloat                  = ts['@float'],
+        TSFuncMacro              = ts['@function.macro'],
+        TSInclude                = ts['@include'],
+        TSLabel                  = ts['@label'],
+        TSNamespace              = ts['@namespace'],
+        TSNumber                 = ts['@number'],
+        TSOperator               = ts['@operator'],
+        TSParameter              = ts['@parameter'],
+        TSProperty               = ts['@property'],
+        TSPunctDelimiter         = ts['@punctutation.delimiter'],
+        TSPunctBracket           = ts['@punctutation.bracket'],
+        TSPunctSpecial           = ts['@punctutation.special'],
+        TSString                 = ts['@string'],
+        TSStringRegex            = ts['@string.regex'],
+        TSStringEscape           = ts['@string.escape'],
+        TSSymbol                 = ts['@symbol'],
+        TSType                   = ts['@type'],
+        TSTypeBuiltin            = ts['@type.builtin'],
+        TSTag                    = ts['@tag'],
+        TSTagDelimiter           = ts['@tag.delimiter'],
+        TSText                   = ts['@text'],
+        TSTextReference          = ts['@text.reference'],
+        TSEmphasis               = ts['@text.emphasis'],
+        TSUnderline              = ts['@text.underline'],
+        TSStrike                 = ts['@text.strikethrough'],
+        TSTitle                  = ts['@text.title'],
+        TSLiteral                = ts['@text.literal'],
+        TSURI                    = ts['@text.uri'],
+
+        ['@lsp.type.namespace']  = ts['@namespace'],
+        ['@lsp.type.type']       = ts['@type'],
+        ['@lsp.type.class']      = ts['@type'],
+        ['@lsp.type.enum']       = ts['@type'],
+        ['@lsp.type.interface']  = ts['@type'],
+        ['@lsp.type.struct']     = ts['@type.definition'],
+        ['@lsp.type.parameter']  = ts['@parameter'],
+        ['@lsp.type.variable']   = ts['@variable'],
+        ['@lsp.type.property']   = ts['@property'],
+        ['@lsp.type.enumMember'] = ts['@constant'],
+        ['@lsp.type.function']   = ts['@function'],
+        ['@lsp.type.method']     = ts['@method'],
+        ['@lsp.type.macro']      = ts['@function.macro'],
+        ['@lsp.type.decorator']  = ts['@function'],
+    }
+
+    -- Options:
+
+    -- Italic comments
+    if vim.g.solarized_italic_comments == true then
+        treesitter.TSComment = { fg = solarized.comments, bg = solarized.none, style = 'bold,italic' } -- For comment blocks.
+    else
+        treesitter.TSComment = ts['@comment'];                                                         -- For comment blocks.
+    end
+
+    if vim.g.solarized_italic_keywords == true then
+        treesitter.TSConditional     = { fg = solarized.greeen, style = 'italic' }     -- For keywords related to conditionnals.
+        treesitter.TSKeyword         = { fg = solarized.green, style = 'italic' }      -- For keywords that don't fall in previous categories.
+        treesitter.TSRepeat          = { fg = solarized.green, style = 'bold,italic' } -- For keywords related to loops.
+        treesitter.TSKeywordFunction = { fg = solarized.green, style = 'bold,italic' } -- For keywords used to define a fuction.
+    else
+        treesitter.TSConditional     = ts['@conditional'];                             -- For keywords related to conditionnals.
+        treesitter.TSKeyword         = ts['@keyword'];                                 -- For keywords that don't fall in previous categories.
+        treesitter.TSRepeat          = ts['@repeat'];                                  -- For keywords related to loops.
+        treesitter.TSKeywordFunction = ts['@keyword.function'];                        -- For keywords used to define a fuction.
+    end
+
+    if vim.g.solarized_italic_functions == true then
+        treesitter.TSFunction    = { fg = solarized.yellow, style = 'bold,italic' } -- For fuction (calls and definitions).
+        treesitter.TSMethod      = { fg = solarized.yellow, style = 'bold,italic' } -- For method calls and definitions.
+        treesitter.TSFuncBuiltin = { fg = solarized.purple, style = 'bold,italic' } -- For builtin functions: `table.insert` in Lua.
+    else
+        treesitter.TSFunction    = ts['@function'];                                 -- For fuction (calls and definitions).
+        treesitter.TSMethod      = ts['@method'];                                   -- For method calls and definitions.
+        treesitter.TSFuncBuiltin = ts['@function.builtin'];                         -- For builtin functions: `table.insert` in Lua.
+    end
+
+    if vim.g.solarized_italic_variables == true then
+        treesitter.TSVariable        = { fg = solarized.gray, style = 'italic' } -- Any variable name that does not have another highlight.
+        treesitter.TSVariableBuiltin = { fg = solarized.gray, style = 'italic' } -- Variable names that are defined by the languages, like `this` or `self`.
+    else
+        treesitter.TSVariable        = ts['@variable'];                          -- Any variable name that does not have another highlight.
+        treesitter.TSVariableBuiltin = ts['@variable.builtin'];                  -- Variable names that are defined by the languages, like `this` or `self`.
+    end
+
+    for k, v in pairs(ts) do treesitter[k] = v end
+
+    return treesitter
+end
+
+theme.loadLSP = function()
     -- Lsp highlight groups
 
     local lsp = {
-        LspDiagnosticsDefaultError =            { fg = solarized.error }, -- used for "Error" diagnostic virtual text
-        LspDiagnosticsSignError =               { fg = solarized.error }, -- used for "Error" diagnostic signs in sign column
-        LspDiagnosticsFloatingError =           { fg = solarized.error }, -- used for "Error" diagnostic messages in the diagnostics float
-        LspDiagnosticsVirtualTextError =        { fg = solarized.error }, -- Virtual text "Error"
-        LspDiagnosticsUnderlineError =          { style = 'undercurl', sp = solarized.error }, -- used to underline "Error" diagnostics.
-        LspDiagnosticsDefaultWarning =          { fg = solarized.purple}, -- used for "Warning" diagnostic signs in sign column
-        LspDiagnosticsSignWarning =             { fg = solarized.purple}, -- used for "Warning" diagnostic signs in sign column
-        LspDiagnosticsFloatingWarning =         { fg = solarized.purple}, -- used for "Warning" diagnostic messages in the diagnostics float
-        LspDiagnosticsVirtualTextWarning =      { fg = solarized.purple}, -- Virtual text "Warning"
-        LspDiagnosticsUnderlineWarning =        { style = 'undercurl', sp = solarized.purple }, -- used to underline "Warning" diagnostics.
-        LspDiagnosticsDefaultInformation =      { fg = solarized.paleblue }, -- used for "Information" diagnostic virtual text
-        LspDiagnosticsSignInformation =         { fg = solarized.paleblue },  -- used for "Information" diagnostic signs in sign column
-        LspDiagnosticsFloatingInformation =     { fg = solarized.paleblue }, -- used for "Information" diagnostic messages in the diagnostics float
-        LspDiagnosticsVirtualTextInformation =  { fg = solarized.paleblue }, -- Virtual text "Information"
-        LspDiagnosticsUnderlineInformation =    { style = 'undercurl', sp = solarized.paleblue }, -- used to underline "Information" diagnostics.
-        LspDiagnosticsDefaultHint =             { fg = solarized.yellow  },  -- used for "Hint" diagnostic virtual text
-        LspDiagnosticsSignHint =                { fg = solarized.yellow  }, -- used for "Hint" diagnostic signs in sign column
-        LspDiagnosticsFloatingHint =            { fg = solarized.yellow  }, -- used for "Hint" diagnostic messages in the diagnostics float
-        LspDiagnosticsVirtualTextHint =         { fg = solarized.yellow  }, -- Virtual text "Hint"
-        LspDiagnosticsUnderlineHint =           { style = 'undercurl', sp = solarized.paleblue }, -- used to underline "Hint" diagnostics.
-        LspReferenceText =                      { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "text" references
-        LspReferenceRead =                      { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "read" references
-        LspReferenceWrite =                     { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "write" references
+        LspDiagnosticsDefaultError           = { fg = solarized.error },                            -- used for "Error" diagnostic virtual text
+        LspDiagnosticsSignError              = { fg = solarized.error },                            -- used for "Error" diagnostic signs in sign column
+        LspDiagnosticsFloatingError          = { fg = solarized.error },                            -- used for "Error" diagnostic messages in the diagnostics float
+        LspDiagnosticsVirtualTextError       = { fg = solarized.error },                            -- Virtual text "Error"
+        LspDiagnosticsUnderlineError         = { style = 'undercurl', sp = solarized.error },       -- used to underline "Error" diagnostics.
+        LspDiagnosticsDefaultWarning         = { fg = solarized.purple },                           -- used for "Warning" diagnostic signs in sign column
+        LspDiagnosticsSignWarning            = { fg = solarized.purple },                           -- used for "Warning" diagnostic signs in sign column
+        LspDiagnosticsFloatingWarning        = { fg = solarized.purple },                           -- used for "Warning" diagnostic messages in the diagnostics float
+        LspDiagnosticsVirtualTextWarning     = { fg = solarized.purple },                           -- Virtual text "Warning"
+        LspDiagnosticsUnderlineWarning       = { style = 'undercurl', sp = solarized.purple },      -- used to underline "Warning" diagnostics.
+        LspDiagnosticsDefaultInformation     = { fg = solarized.paleblue },                         -- used for "Information" diagnostic virtual text
+        LspDiagnosticsSignInformation        = { fg = solarized.paleblue },                         -- used for "Information" diagnostic signs in sign column
+        LspDiagnosticsFloatingInformation    = { fg = solarized.paleblue },                         -- used for "Information" diagnostic messages in the diagnostics float
+        LspDiagnosticsVirtualTextInformation = { fg = solarized.paleblue },                         -- Virtual text "Information"
+        LspDiagnosticsUnderlineInformation   = { style = 'undercurl', sp = solarized.paleblue },    -- used to underline "Information" diagnostics.
+        LspDiagnosticsDefaultHint            = { fg = solarized.yellow },                           -- used for "Hint" diagnostic virtual text
+        LspDiagnosticsSignHint               = { fg = solarized.yellow },                           -- used for "Hint" diagnostic signs in sign column
+        LspDiagnosticsFloatingHint           = { fg = solarized.yellow },                           -- used for "Hint" diagnostic messages in the diagnostics float
+        LspDiagnosticsVirtualTextHint        = { fg = solarized.yellow },                           -- Virtual text "Hint"
+        LspDiagnosticsUnderlineHint          = { style = 'undercurl', sp = solarized.paleblue },    -- used to underline "Hint" diagnostics.
+        LspReferenceText                     = { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "text" references
+        LspReferenceRead                     = { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "read" references
+        LspReferenceWrite                    = { fg = solarized.accent, bg = solarized.highlight }, -- used for highlighting "write" references
     }
 
     return lsp
-
 end
 
 theme.loadPlugins = function()
     -- Plugins highlight groups
 
     local plugins = {
-
         -- LspTrouble
-        LspTroubleText =                        { fg = solarized.text },
-        LspTroubleCount =                       { fg = solarized.yellow, bg = solarized.active },
-        LspTroubleNormal =                      { fg = solarized.fg, bg = solarized.sidebar },
+        LspTroubleText              = { fg = solarized.text },
+        LspTroubleCount             = { fg = solarized.yellow, bg = solarized.active },
+        LspTroubleNormal            = { fg = solarized.fg, bg = solarized.sidebar },
 
         -- Diff
-        diffAdded =                             { fg = solarized.green },
-        diffRemoved =                           { fg = solarized.red },
-        diffChanged =                           { fg = solarized.purple },
-        diffOldFile =                           { fg = solarized.yelow },
-        diffNewFile =                           { fg = solarized.orange },
-        diffFile =                              { fg = solarized.blue },
-        diffLine =                              { fg = solarized.comments },
-        diffIndexLine =                         { fg = solarized.yellow },
+        diffAdded                   = { fg = solarized.green },
+        diffRemoved                 = { fg = solarized.red },
+        diffChanged                 = { fg = solarized.purple },
+        diffOldFile                 = { fg = solarized.yelow },
+        diffNewFile                 = { fg = solarized.orange },
+        diffFile                    = { fg = solarized.blue },
+        diffLine                    = { fg = solarized.comments },
+        diffIndexLine               = { fg = solarized.yellow },
 
         -- Neogit
-        NeogitBranch =                          { fg = solarized.paleblue },
-        NeogitRemote =                          { fg = solarized.yellow },
-        NeogitHunkHeader =                      { fg = solarized.fg, bg = solarized.highlight },
-        NeogitHunkHeaderHighlight =             { fg = solarized.blue, bg = solarized.contrast },
-        NeogitDiffContextHighlight =            { fg = solarized.text, bg = solarized.contrast },
-        NeogitDiffDeleteHighlight =             { fg = solarized.red },
-        NeogitDiffAddHighlight =                { fg = solarized.green },
+        NeogitBranch                = { fg = solarized.paleblue },
+        NeogitRemote                = { fg = solarized.yellow },
+        NeogitHunkHeader            = { fg = solarized.fg, bg = solarized.highlight },
+        NeogitHunkHeaderHighlight   = { fg = solarized.blue, bg = solarized.contrast },
+        NeogitDiffContextHighlight  = { fg = solarized.text, bg = solarized.contrast },
+        NeogitDiffDeleteHighlight   = { fg = solarized.red },
+        NeogitDiffAddHighlight      = { fg = solarized.green },
 
         -- GitGutter
-        GitGutterAdd =                          { fg = solarized.green }, -- diff mode: Added line |diff.txt|
-        GitGutterChange =                       { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
-        GitGutterDelete =                       { fg = solarized.red }, -- diff mode: Deleted line |diff.txt|
+        GitGutterAdd                = { fg = solarized.green },  -- diff mode: Added line |diff.txt|
+        GitGutterChange             = { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
+        GitGutterDelete             = { fg = solarized.red },    -- diff mode: Deleted line |diff.txt|
 
         -- GitSigns
-        GitSignsAdd =                           { fg = solarized.green }, -- diff mode: Added line |diff.txt|
-        GitSignsAddNr =                         { fg = solarized.green }, -- diff mode: Added line |diff.txt|
-        GitSignsAddLn =                         { fg = solarized.green }, -- diff mode: Added line |diff.txt|
-        GitSignsChange =                        { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
-        GitSignsChangeNr =                      { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
-        GitSignsChangeLn =                      { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
-        GitSignsDelete =                        { fg = solarized.red }, -- diff mode: Deleted line |diff.txt|
-        GitSignsDeleteNr =                      { fg = solarized.red }, -- diff mode: Deleted line |diff.txt|
-        GitSignsDeleteLn =                      { fg = solarized.red }, -- diff mode: Deleted line |diff.txt|
+        GitSignsAdd                 = { fg = solarized.green },  -- diff mode: Added line |diff.txt|
+        GitSignsAddNr               = { fg = solarized.green },  -- diff mode: Added line |diff.txt|
+        GitSignsAddLn               = { fg = solarized.green },  -- diff mode: Added line |diff.txt|
+        GitSignsChange              = { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
+        GitSignsChangeNr            = { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
+        GitSignsChangeLn            = { fg = solarized.purple }, -- diff mode: Changed line |diff.txt|
+        GitSignsDelete              = { fg = solarized.red },    -- diff mode: Deleted line |diff.txt|
+        GitSignsDeleteNr            = { fg = solarized.red },    -- diff mode: Deleted line |diff.txt|
+        GitSignsDeleteLn            = { fg = solarized.red },    -- diff mode: Deleted line |diff.txt|
 
         -- Telescope
-        TelescopePromptBorder =                 { fg = solarized.cyan },
-        TelescopeResultsBorder =                { fg = solarized.yellow },
-        TelescopePreviewBorder =                { fg = solarized.green },
-        TelescopeSelectionCaret =               { fg = solarized.yellow },
-        TelescopeSelection =                    { fg = solarized.yellow },
-        TelescopeMatching =                     { fg = solarized.cyan },
-        TelescopeNormal =                       { fg = solarized.fg, bg = solarized.float },
+        TelescopePromptBorder       = { fg = solarized.cyan },
+        TelescopeResultsBorder      = { fg = solarized.yellow },
+        TelescopePreviewBorder      = { fg = solarized.green },
+        TelescopeSelectionCaret     = { fg = solarized.yellow },
+        TelescopeSelection          = { fg = solarized.yellow },
+        TelescopeMatching           = { fg = solarized.cyan },
+        TelescopeNormal             = { fg = solarized.fg, bg = solarized.float },
 
         -- NvimTree
-        NvimTreeRootFolder =                    { fg = solarized.blue, style = "bold" },
-        NvimTreeGitDirty =                      { fg = solarized.purple },
-        NvimTreeGitNew =                        { fg = solarized.green },
-        NvimTreeImageFile =                     { fg = solarized.purple },
-        NvimTreeExecFile =                      { fg = solarized.green },
-        NvimTreeSpecialFile =                   { fg = solarized.yellow , style = "underline" },
-        NvimTreeFolderName=                     { fg = solarized.paleblue },
-        NvimTreeEmptyFolderName=                { fg = solarized.disabled },
-        NvimTreeFolderIcon=                     { fg = solarized.accent },
-        NvimTreeIndentMarker =                  { fg  = solarized.disabled },
-        LspDiagnosticsError =                   { fg = solarized.error },
-        LspDiagnosticsWarning =                 { fg = solarized.purple },
-        LspDiagnosticsInformation =             { fg = solarized.paleblue },
-        LspDiagnosticsHint =                    { fg = solarized.yellow },
+        NvimTreeRootFolder          = { fg = solarized.blue, style = 'bold' },
+        NvimTreeGitDirty            = { fg = solarized.purple },
+        NvimTreeGitNew              = { fg = solarized.green },
+        NvimTreeImageFile           = { fg = solarized.purple },
+        NvimTreeExecFile            = { fg = solarized.green },
+        NvimTreeSpecialFile         = { fg = solarized.yellow, style = 'underline' },
+        NvimTreeFolderName          = { fg = solarized.paleblue },
+        NvimTreeEmptyFolderName     = { fg = solarized.disabled },
+        NvimTreeFolderIcon          = { fg = solarized.accent },
+        NvimTreeIndentMarker        = { fg = solarized.disabled },
+        LspDiagnosticsError         = { fg = solarized.error },
+        LspDiagnosticsWarning       = { fg = solarized.purple },
+        LspDiagnosticsInformation   = { fg = solarized.paleblue },
+        LspDiagnosticsHint          = { fg = solarized.yellow },
 
         -- WhichKey
-        WhichKey =                              { fg = solarized.accent , style = 'bold'},
-        WhichKeyGroup =                         { fg = solarized.text },
-        WhichKeyDesc =                          { fg = solarized.blue, style = 'italic' },
-        WhichKeySeperator =                     { fg = solarized.fg },
-        WhichKeyFloating =                      { bg = solarized.float },
-        WhichKeyFloat =                         { bg = solarized.float },
+        WhichKey                    = { fg = solarized.accent, style = 'bold' },
+        WhichKeyGroup               = { fg = solarized.text },
+        WhichKeyDesc                = { fg = solarized.blue, style = 'italic' },
+        WhichKeySeperator           = { fg = solarized.fg },
+        WhichKeyFloating            = { bg = solarized.float },
+        WhichKeyFloat               = { bg = solarized.float },
 
         -- LspSaga
-        DiagnosticError =                       { fg = solarized.error },
-        DiagnosticWarning =                     { fg = solarized.purple },
-        DiagnosticInformation =                 { fg = solarized.paleblue },
-        DiagnosticHint =                        { fg = solarized.yellow },
-        DiagnosticTruncateLine =                { fg = solarized.fg },
-        LspFloatWinNormal =                     { bg = solarized.contrast },
-        LspFloatWinBorder =                     { fg = solarized.yellow },
-        LspSagaBorderTitle =                    { fg = solarized.cyan },
-        LspSagaHoverBorder =                    { fg = solarized.paleblue },
-        LspSagaRenameBorder =                   { fg = solarized.green },
-        LspSagaDefPreviewBorder =               { fg = solarized.green },
-        LspSagaCodeActionBorder =               { fg = solarized.blue },
-        LspSagaFinderSelection =                { fg = solarized.green },
-        LspSagaCodeActionTitle =                { fg = solarized.paleblue },
-        LspSagaCodeActionContent =              { fg = solarized.yellow },
-        LspSagaSignatureHelpBorder =            { fg = solarized.gray },
-        ReferencesCount =                       { fg = solarized.yellow },
-        DefinitionCount =                       { fg = solarized.yellow },
-        DefinitionIcon =                        { fg = solarized.blue },
-        ReferencesIcon =                        { fg = solarized.blue },
-        TargetWord =                            { fg = solarized.cyan },
+        DiagnosticError             = { fg = solarized.error },
+        DiagnosticWarning           = { fg = solarized.purple },
+        DiagnosticInformation       = { fg = solarized.paleblue },
+        DiagnosticHint              = { fg = solarized.yellow },
+        DiagnosticTruncateLine      = { fg = solarized.fg },
+        LspFloatWinNormal           = { bg = solarized.contrast },
+        LspFloatWinBorder           = { fg = solarized.yellow },
+        LspSagaBorderTitle          = { fg = solarized.cyan },
+        LspSagaHoverBorder          = { fg = solarized.paleblue },
+        LspSagaRenameBorder         = { fg = solarized.green },
+        LspSagaDefPreviewBorder     = { fg = solarized.green },
+        LspSagaCodeActionBorder     = { fg = solarized.blue },
+        LspSagaFinderSelection      = { fg = solarized.green },
+        LspSagaCodeActionTitle      = { fg = solarized.paleblue },
+        LspSagaCodeActionContent    = { fg = solarized.yellow },
+        LspSagaSignatureHelpBorder  = { fg = solarized.gray },
+        ReferencesCount             = { fg = solarized.yellow },
+        DefinitionCount             = { fg = solarized.yellow },
+        DefinitionIcon              = { fg = solarized.blue },
+        ReferencesIcon              = { fg = solarized.blue },
+        TargetWord                  = { fg = solarized.cyan },
 
         -- BufferLine
-        BufferLineIndicatorSelected =           { fg = solarized.accent },
-        BufferLineFill =                        { bg = solarized.bg_alt },
+        BufferLineIndicatorSelected = { fg = solarized.accent },
+        BufferLineFill              = { bg = solarized.bg_alt },
 
         -- Sneak
-        Sneak =                                 { fg = solarized.bg, bg = solarized.accent },
-        SneakScope =                            { bg = solarized.selection },
+        Sneak                       = { fg = solarized.bg, bg = solarized.accent },
+        SneakScope                  = { bg = solarized.selection },
 
         -- Indent Blankline
-        IndentBlanklineChar =                   { fg = solarized.highlight },
-        IndentBlanklineContextChar =            { fg = solarized.disabled },
-	
-	 -- Nvim dap
-         DapBreakpoint =                         { fg = solarized.red },
-         DapStopped =                            { fg = solarized.green },
+        IndentBlanklineChar         = { fg = solarized.highlight },
+        IndentBlanklineContextChar  = { fg = solarized.disabled },
+
+        -- Nvim dap
+        DapBreakpoint               = { fg = solarized.red },
+        DapStopped                  = { fg = solarized.green },
     }
 
     -- Options:
 
     -- Disable nvim-tree background
-        if vim.g.solarized_disable_background == true then
-            plugins.NvimTreeNormal =                        { fg = solarized.fg, bg = solarized.none }
-        else
-            plugins.NvimTreeNormal =                        { fg = solarized.fg, bg = solarized.sidebar }
-        end
+    if vim.g.solarized_disable_background == true then
+        plugins.NvimTreeNormal = { fg = solarized.fg, bg = solarized.none }
+    else
+        plugins.NvimTreeNormal = { fg = solarized.fg, bg = solarized.sidebar }
+    end
 
     return plugins
-
 end
 
 return theme

--- a/lua/solarized/treesitter.lua
+++ b/lua/solarized/treesitter.lua
@@ -1,0 +1,124 @@
+local solarized = require('solarized.colors')
+
+local syntax = {
+    -- Properties source: https://github.com/nvim-treesitter/nvim-treesitter/blob/9fa6806b88905d52b5ca36094909630919b432cc/CONTRIBUTING.md
+
+    -- Misc
+    ['@comment']               = { fg = solarized.comments },                  -- line and block comments
+    ['@comment.documentation'] = { fg = solarized.comments },                  -- comments documenting code
+    ['@error']                 = { fg = solarized.error, style = 'bold' },     -- syntax/parser errors
+    ['@none']                  = { fg = solarized.none, bg = solarized.none }, -- completely disable the highlight
+    ['@preproc']               = { fg = solarized.yellow },                    -- various preprocessor directives & shebangs
+    ['@define']                = { fg = solarized.gray },                      -- preprocessor definition directives
+    ['@operator']              = { fg = solarized.cyan },                      -- symbolic operators (e.g. `+` / `*`)
+
+    -- Punctuation
+    ['@punctuation.delimiter'] = { fg = solarized.black }, -- delimiters (e.g. `= {}, --` / `.` / `,`)
+    ['@punctuation.bracket']   = { fg = solarized.black }, -- brackets (e.g. `()` / `{},` / `[]`)
+    ['@punctuation.special']   = { fg = solarized.black }, -- special symbols (e.g. `{},` in string interpolation)
+
+    -- Literals
+    ['@string']                = { fg = solarized.green },                   -- string literals
+    ['@string.documentation']  = { fg = solarized.green, style = 'italic' }, -- string documenting code (e.g. Python docstrings)
+    ['@string.regex']          = { fg = solarized.green, style = 'bold' },   -- regular expressions
+    ['@string.escape']         = { fg = solarized.disabled },                -- escape sequences
+    ['@string.special']        = { fg = solarized.green },                   -- other special strings (e.g. dates)
+
+    ['@character']             = { fg = solarized.orange },                  -- character literals
+    ['@character.special']     = { fg = solarized.orange, style = 'bold' },  -- special characters (e.g. wildcards)
+
+    ['@boolean']               = { fg = solarized.orange },                  -- boolean literals
+    ['@number']                = { fg = solarized.orange },                  -- numeric literals
+    ['@float']                 = { fg = solarized.orange },                  -- floating-point number literals
+
+    -- Functions
+    ['@function']              = { fg = solarized.yellow, style = 'bold' },   -- function definitions
+    ['@function.builtin']      = { fg = solarized.yellow, style = 'italic' }, -- built-in functions
+    ['@function.call']         = { fg = solarized.yellow },                   -- function calls
+    ['@function.macro']        = { fg = solarized.blue },                     -- preprocessor macros
+
+    ['@method']                = { fg = solarized.yellow, style = 'bold' },   -- method definitions
+    ['@method.call']           = { fg = solarized.yellow },                   -- method calls
+
+    ['@constructor']           = { fg = solarized.yellow },                   -- constructor calls and definitions
+    ['@parameter']             = { fg = solarized.blue },                     -- parameters of a function
+
+    -- Keywords
+    ['@keyword']               = { fg = solarized.green },                  -- various keywords
+    ['@keyword.coroutine']     = { fg = solarized.green },                  -- keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
+    ['@keyword.function']      = { fg = solarized.yellow, style = 'bold' }, -- keywords that define a function (e.g. `func` in Go, `def` in Python)
+    ['@keyword.operator']      = { fg = solarized.cyan },                   -- operators that are English words (e.g. `and` / `or`)
+    ['@keyword.return']        = { fg = solarized.green },                  -- keywords like `return` and `yield`
+
+    ['@conditional']           = { fg = solarized.cyan },                   -- keywords related to conditionals (e.g. `if` / `else`)
+    ['@conditional.ternary']   = { fg = solarized.cyan },                   -- ternary operator (e.g. `?` / `:`)
+
+    ['@repeat']                = { fg = solarized.cyan },                   -- keywords related to loops (e.g. `for` / `while`)
+    ['@debug']                 = { fg = solarized.red },                    -- keywords related to debugging
+    ['@label']                 = { fg = solarized.yellow },                 -- GOTO and other labels (e.g. `label:` in C)
+    ['@include']               = { fg = solarized.cyan, style = 'bold' },   -- keywords for including modules (e.g. `import` / `from` in Python)
+    ['@exception']             = { fg = solarized.purple, style = 'bold' }, -- keywords related to exceptions (e.g. `throw` / `catch`)
+
+    -- Types
+    ['@type']                  = { fg = solarized.yellow, style = 'bold' },   -- type or class definitions and annotations
+    ['@type.builtin']          = { fg = solarized.yellow, style = 'italic' }, -- built-in types
+    ['@type.definition']       = { fg = solarized.yellow },                   -- type definitions (e.g. `typedef` in C)
+    ['@type.qualifier']        = { fg = solarized.yellow },                   -- type qualifiers (e.g. `const`)
+
+    ['@storageclass']          = { fg = solarized.cyan },                     -- modifiers that affect storage in memory or life-time
+    ['@attribute']             = { fg = solarized.purple },                   -- attribute annotations (e.g. Python decorators)
+    ['@field']                 = { fg = solarized.gray },                     -- object and struct fields
+    ['@property']              = { fg = solarized.gray },                     -- similar to `@field`
+
+    -- Identifiers
+    ['@variable']              = { fg = solarized.gray },                     -- various variable names
+    ['@variable.builtin']      = { fg = solarized.purple, style = 'italic' }, -- built-in variable names (e.g. `this`)
+
+    ['@constant']              = { fg = solarized.purple },                   -- constant identifiers
+    ['@constant.builtin']      = { fg = solarized.purple, style = 'italic' }, -- built-in constant values
+    ['@constant.macro']        = { fg = solarized.blue },                     -- constants defined by the preprocessor
+
+    ['@namespace']             = { fg = solarized.purple },                   -- modules or namespaces
+    ['@symbol']                = { fg = solarized.purple },                   -- symbols or atoms
+
+    -- Text
+    -- Mainly for markup languages.
+    ['@text']                  = { fg = solarized.text },                          -- non-structured text
+    ['@text.strong']           = { fg = solarized.text, style = 'bold' },          -- bold text
+    ['@text.emphasis']         = { fg = solarized.text, style = 'italic' },        -- text with emphasis
+    ['@text.underline']        = { fg = solarized.text, style = 'underline' },     -- underlined text
+    ['@text.strike']           = { fg = solarized.text, style = 'strikethrough' }, -- strikethrough text
+    ['@text.title']            = { fg = solarized.paleblue, style = 'bold' },      -- text that is part of a title
+    ['@text.quote']            = { fg = solarized.text, style = 'italic' },        -- text quotations
+    ['@text.uri']              = { fg = solarized.link },                          -- URIs (e.g. hyperlinks)
+    ['@text.math']             = { fg = solarized.text },                          -- math environments (e.g. `$ ... $` in LaTeX)
+    ['@text.environment']      = { fg = solarized.text },                          -- text environments of markup languages
+    ['@text.environment.name'] = { fg = solarized.text },                          -- text indicating the type of an environment
+    ['@text.reference']        = { fg = solarized.purple },                        -- text references, footnotes, citations, etc.
+
+    ['@text.literal']          = { fg = solarized.fg },                            -- literal or verbatim text (e.g., inline code)
+    ['@text.literal.block']    = { fg = solarized.fg },                            -- literal or verbatim text as a stand-alone block (use priority 90 for blocks with injections)
+
+    ['@text.todo']             = { fg = solarized.purple, style = 'bold' },        -- todo notes
+    ['@text.note']             = { fg = solarized.text },                          -- info notes
+    ['@text.warning']          = { fg = solarized.purple },                        -- warning notes
+    ['@text.danger']           = { fg = solarized.red, style = 'bold' },           -- danger/error notes
+
+    ['@text.diff.add']         = { fg = solarized.green },                         -- added text (for diff files)
+    ['@text.diff.delete']      = { fg = solarized.red },                           -- deleted text (for diff files)
+
+    -- Tags
+    -- Used for XML-like tags.
+    ['@tag']                   = { fg = solarized.yellow, style = 'bold' }, -- XML tag names
+    ['@tag.attribute']         = { fg = solarized.green },                  -- XML tag attributes
+    ['@tag.delimiter']         = { fg = solarized.yellow },                 -- XML tag delimiters
+
+    -- Conceal
+    ['@conceal']               = { fg = solarized.disabled }, -- for captures that are only used for concealing, `@conceal` must be followed by `(#set! conceal "")`.
+
+    -- Spell
+    ['@spell']                 = {}, -- for defining regions to be spellchecked
+    ['@nospell']               = {}, -- for defining regions that should NOT be spellchecked
+}
+
+return syntax

--- a/lua/solarized/util.lua
+++ b/lua/solarized/util.lua
@@ -2,28 +2,28 @@ local util = {}
 local solarized = require('solarized.theme')
 
 -- Go trough the table and highlight the group with the color values
-util.highlight = function (group, color)
-    local style = color.style and "gui=" .. color.style or "gui=NONE"
-    local fg = color.fg and "guifg=" .. color.fg or "guifg=NONE"
-    local bg = color.bg and "guibg=" .. color.bg or "guibg=NONE"
-    local sp = color.sp and "guisp=" .. color.sp or ""
+util.highlight = function(group, color)
+    local style = color.style and 'gui=' .. color.style or 'gui=NONE'
+    local fg = color.fg and 'guifg=' .. color.fg or 'guifg=NONE'
+    local bg = color.bg and 'guibg=' .. color.bg or 'guibg=NONE'
+    local sp = color.sp and 'guisp=' .. color.sp or ''
 
-    local hl = "highlight " .. group .. " " .. style .. " " .. fg .. " " .. bg .. " " .. sp
+    local hl = 'highlight ' .. group .. ' ' .. style .. ' ' .. fg .. ' ' .. bg .. ' ' .. sp
 
     vim.cmd(hl)
-    if color.link then vim.cmd("highlight! link " .. group .. " " .. color.link) end
+    if color.link then vim.cmd('highlight! link ' .. group .. ' ' .. color.link) end
 end
 
 -- Only define Solarized if it's the active colorshceme
 function util.onColorScheme()
-  if vim.g.colors_name ~= "solarized" then
-    vim.cmd [[autocmd! Solarized]]
-    vim.cmd [[augroup! Solarized]]
-  end
+    if vim.g.colors_name ~= 'solarized' then
+        vim.cmd [[autocmd! Solarized]]
+        vim.cmd [[augroup! Solarized]]
+    end
 end
 
 -- Change the background for the terminal, packer and qf windows
-util.contrast = function ()
+util.contrast = function()
     vim.cmd [[augroup Solarized]]
     vim.cmd [[  autocmd!]]
     vim.cmd [[  autocmd ColorScheme * lua require("solarized.util").onColorScheme()]]
@@ -36,21 +36,21 @@ end
 -- Load the theme
 function util.load()
     -- Set the theme environment
-    vim.cmd("hi clear")
-    if vim.fn.exists("syntax_on") then vim.cmd("syntax reset") end
+    vim.cmd('hi clear')
+    if vim.fn.exists('syntax_on') then vim.cmd('syntax reset') end
     if not vim.o.background then
-        vim.o.background = "light"
+        vim.o.background = 'light'
     end
     vim.o.termguicolors = true
-    vim.g.colors_name = "solarized"
+    vim.g.colors_name = 'solarized'
 
     -- Load plugins, treesitter and lsp async
     local async
-    async = vim.loop.new_async(vim.schedule_wrap(function ()
+    async = vim.loop.new_async(vim.schedule_wrap(function()
         solarized.loadTerminal()
 
         -- imort tables for plugins, treesitter and lsp
-        tables = {
+        local tables = {
             plugins = solarized.loadPlugins(),
             treesitter = solarized.loadTreeSitter(),
             lsp = solarized.loadLSP(),
@@ -64,7 +64,6 @@ function util.load()
             util.contrast()
         end
         async:close()
-
     end))
 
     -- load the most importaint parts of the theme


### PR DESCRIPTION
While playing with Treesitter, I noticed it didn't play well with this theme.

This PR includes:
- Adds @-based colors and references them in the base syntax and TS syntax.
- Adds @lsp references.
- Formatting (by lua_ls and aligning the `=` for a nice columnar overview.

I've tried to keep it close to what it already was but might introduce a few minor changes to color/style that better fit my taste.

This PR might be too big of a change or too opinionated on formatting, feel free to decline this PR (or take parts that you might like).