### PR TITLE
Tweaks: fix CursorLineNr background and add rule for Whitespace highlight group

### DIFF
--- a/lua/solarized/theme.lua
+++ b/lua/solarized/theme.lua
@@ -148,6 +148,7 @@ theme.loadEditor = function ()
 		VisualMode =			{ fg = solarized.yellow, bg = solarized.none, style = 'reverse' },
 		CommandMode =			{ fg = solarized.gray, bg = solarized.none, style = 'reverse' },
 		Warnings =				{ fg = solarized.purple },
+		Whitespace =			{ fg = solarized.highlight },
 
         healthError =           { fg = solarized.error },
         healthSuccess =         { fg = solarized.green },

--- a/lua/solarized/theme.lua
+++ b/lua/solarized/theme.lua
@@ -108,7 +108,7 @@ theme.loadEditor = function ()
 		FoldColumn =			{ fg = solarized.blue },
 		IncSearch =				{ fg = solarized.highlight, bg = solarized.white, style = 'reverse' },
 		LineNr =				{ fg = solarized.line_numbers, bg = solarized.bg_alt },
-		CursorLineNr =			{ fg = solarized.accent },
+		CursorLineNr =			{ fg = solarized.accent, bg = solarized.bg_alt },
 		MatchParen =			{ fg = solarized.purple, bg = solarized.none, style = 'bold' },
 		ModeMsg =				{ fg = solarized.accent },
 		MoreMsg =				{ fg = solarized.accent },


### PR DESCRIPTION
Using Vim options:

```
    cursorline = true,
    number = true,
    list = true,
    listchars = 'tab:──╴,trail:&,nbsp:^',
```

Before CursorLineNr commit:
![image](https://github.com/shaunsingh/solarized.nvim/assets/1281068/f91df484-2c77-4c32-aa1a-86731c8f1d49)
After CursorLineNr commit:
![image](https://github.com/shaunsingh/solarized.nvim/assets/1281068/8acc2d50-0201-460c-857f-bb889a480fcd)

Before Whitespace commit:
![image](https://github.com/shaunsingh/solarized.nvim/assets/1281068/f86370d4-27f5-44d8-9ee5-14cc1bf9c3cb)
After Whitespace commit:
![image](https://github.com/shaunsingh/solarized.nvim/assets/1281068/b6d6c6cf-b19f-4d39-b071-ed9a178303c8)
